### PR TITLE
feat(cluster): optional keyspace added in the cluster connection

### DIFF
--- a/addon/src/main.cpp
+++ b/addon/src/main.cpp
@@ -3,7 +3,7 @@
 #include <scylladb_wrapper/cluster/cluster.hpp>
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
-  exports.Set(Napi::String::New(env, "Cluster"), scylladb_wrapper::cluster::Cluster::GetClass(env));
+  exports.Set("Cluster", scylladb_wrapper::cluster::Cluster::GetClass(env));
   return exports;
 }
 

--- a/node_modules/@nodepp/example/index.d.ts
+++ b/node_modules/@nodepp/example/index.d.ts
@@ -8,11 +8,11 @@ type ClusterOptions = {
 
 class Cluster {
   constructor(options?: ClusterOptions);
-  connect(): Session;
+  connect(keyspace?: string): Session;
 }
 
 interface Session {
-  executeSync(query: string): Array<string>; // This string should be a row later
+  executeSync<T>(query: string): Array<T>; // This string should be a row later
 }
 
 declare namespace NodeppExampleModule {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ const cluster = new Cluster({
   nodes: ["172.21.0.2"],
 });
 
-const session = cluster.connect();
-const keyspaceName = session.executeSync(
-  "SELECT table_name FROM system_schema.scylla_tables"
+const session = cluster.connect("system_schema");
+const keyspaceName = session.executeSync<{ table_name: string }>(
+  "SELECT table_name FROM scylla_tables"
 );
 console.log(keyspaceName);


### PR DESCRIPTION
```diff
import { Cluster } from "@nodepp/example";

const cluster = new Cluster({
  nodes: ["172.21.0.2"],
});

+ const session = cluster.connect("system_schema");
- const session = cluster.connect();
```